### PR TITLE
Fix multi-sections

### DIFF
--- a/hdyndns/cli.py
+++ b/hdyndns/cli.py
@@ -23,10 +23,12 @@ def cli_entrypoint() -> None:
     validate_api_secrets(config, sections)
 
     for section in sections:
+        logger.info('Section {}'.format(section))
+
         if 'gandi' == config[section]['provider']:
             logger.info('Processing {} with provider Gandi'.format(section))
             GandiDynDNS(config[section]).update_dns()
-            exit(EXIT_CODE_0_OK)
         else:
             logger.critical('No supported provider found')
-            exit(EXIT_CODE_1_BAD)
+
+    exit(EXIT_CODE_0_OK)

--- a/hdyndns/providers.py
+++ b/hdyndns/providers.py
@@ -103,7 +103,7 @@ class GandiDynDNS():
         if dns_ip == dynamic_ip:
             message = 'DNS A record and Dynamic IP for {} match'
             logger.info(message.format(self.domain))
-            exit(EXIT_CODE_0_OK)
+            return
 
         headers = {
             'X-Api-Key': self.api_secret,
@@ -119,5 +119,3 @@ class GandiDynDNS():
             }
             put(url, payload, headers=headers)
             logger.info('Updated {} entry with IP {}'.format(name, dynamic_ip))
-
-        exit(EXIT_CODE_0_OK)


### PR DESCRIPTION
To record several websites.

We could remove all these `exit` and raise an exception instead? 
Caught in this for loop:

https://github.com/decentral1se/hdyndns/blob/6a7ca0a4945c6202d96617d662a7491612e23fcb/hdyndns/cli.py#L25-L32